### PR TITLE
defer reply to summoner command to avoid timeouts

### DIFF
--- a/src/Commands/Command.Summoner.ts
+++ b/src/Commands/Command.Summoner.ts
@@ -52,6 +52,7 @@ const command: Command = {
                 .setRequired(true);
         }),
     execute: async (interaction) => {
+        interaction.deferReply();
         const name = interaction.options.get('name').value.toString();
         const region = interaction.options.get('region').value.toString();
 
@@ -140,7 +141,7 @@ const command: Command = {
                 )
                 .setThumbnail(summoner.iconUrl);
 
-            await interaction.reply({
+            await interaction.editReply({
                 embeds: [summonerEmbed],
                 components: [buttons],
             });


### PR DESCRIPTION
when response will take longer than 3 seconds, command will fail; to prevent that it might be a good idea to defer the response to avoid such cases